### PR TITLE
feat: Added Lands Support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>me.bestemor.villagermarket</groupId>
     <artifactId>VillagerMarket</artifactId>
-    <version>1.11.7-SNAPSHOT</version>
+    <version>1.11.8-SNAPSHOT</version>
 
     <repositories>
         <repository>
@@ -131,6 +131,14 @@
             <artifactId>citizens-main</artifactId>
             <version>2.0.27-SNAPSHOT</version>
             <type>jar</type>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- LandsAPI -->
+        <dependency>
+            <groupId>com.github.angeschossen</groupId>
+            <artifactId>LandsAPI</artifactId>
+            <version>7.1.12</version>
             <scope>provided</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>me.bestemor.villagermarket</groupId>
     <artifactId>VillagerMarket</artifactId>
-    <version>1.11.8-SNAPSHOT</version>
+    <version>1.12.0-SNAPSHOT</version>
 
     <repositories>
         <repository>

--- a/src/main/java/net/bestemor/villagermarket/listener/PlayerListener.java
+++ b/src/main/java/net/bestemor/villagermarket/listener/PlayerListener.java
@@ -12,6 +12,9 @@ import com.sk89q.worldguard.protection.ApplicableRegionSet;
 import com.sk89q.worldguard.protection.managers.RegionManager;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 import de.tr7zw.nbtapi.NBTItem;
+import me.angeschossen.lands.api.LandsIntegration;
+import me.angeschossen.lands.api.flags.type.Flags;
+import me.angeschossen.lands.api.land.LandWorld;
 import net.bestemor.core.config.ConfigManager;
 import net.bestemor.core.config.VersionUtils;
 import net.bestemor.core.utils.UpdateChecker;
@@ -24,10 +27,7 @@ import net.bestemor.villagermarket.shop.ShopMenu;
 import net.bestemor.villagermarket.shop.VillagerShop;
 import net.bestemor.villagermarket.utils.VMUtils;
 import net.citizensnpcs.api.CitizensAPI;
-import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
-import org.bukkit.Location;
-import org.bukkit.NamespacedKey;
+import org.bukkit.*;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -257,11 +257,24 @@ public class PlayerListener implements Listener {
                 }
             }
 
+            Location location = clickedLoc.clone().add(0.5, 1, 0.5);
+
+            //Lands check
+            if (Bukkit.getPluginManager().isPluginEnabled("Lands") && ConfigManager.getBoolean("lands")) {
+                LandsIntegration api = LandsIntegration.of(plugin);
+                LandWorld world = api.getWorld(player.getWorld());
+
+                if (world != null && !world.hasRoleFlag(player.getUniqueId(), location, Flags.BLOCK_PLACE)) {
+                    player.sendMessage(ConfigManager.getMessage("messages.region_no_access"));
+                    return;
+                }
+            }
+
             if (!player.hasPermission("villagermarket.use_spawn_item")) {
                 player.sendMessage(ConfigManager.getMessage("messages.no_permission_use_item"));
                 return;
             }
-            Location location = clickedLoc.clone().add(0.5, 1, 0.5);
+
 
             PlaceShopEggEvent eggEvent = new PlaceShopEggEvent(player, location, shopSize, storageSize);
             Bukkit.getPluginManager().callEvent(eggEvent);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -75,6 +75,8 @@ villager:
 world_guard: false
 #Enable PlotSquared support
 plot_squared: true
+#Enable Lands support
+lands: true
 towny:
   #Enable towny support
   enabled: true

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: VillagerMarket
 main: net.bestemor.villagermarket.VMPlugin
-version: 1.11.7
+version: 1.11.8
 
 author: Bestem0r
 description: A plugin made by Bestem0r to create Villager Shops

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -19,6 +19,7 @@ softdepend:
   - Citizens
   - Towny
   - NBTApi
+  - Lands
 commands:
   vm:
     description: List all Villager Market commands

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: VillagerMarket
 main: net.bestemor.villagermarket.VMPlugin
-version: 1.11.8
+version: 1.12.0
 
 author: Bestem0r
 description: A plugin made by Bestem0r to create Villager Shops


### PR DESCRIPTION
Added Support for [Lands](https://www.spigotmc.org/resources/lands-%E2%AD%95-land-claim-plugin-%E2%9C%85-grief-prevention-protection-gui-management-nations-wars-1-20-support.53313/) - A towny-like claim Plugin