### PR TITLE
can't place shop spawneggs on plotSquared streets anymore

### DIFF
--- a/src/main/java/net/bestemor/villagermarket/listener/PlayerListener.java
+++ b/src/main/java/net/bestemor/villagermarket/listener/PlayerListener.java
@@ -217,9 +217,14 @@ public class PlayerListener implements Listener {
                         clickedLoc.getWorld().getName(), clickedLoc.getBlockX(), clickedLoc.getBlockY(), clickedLoc.getBlockZ());
 
                 PlotArea area = plotAPI.getPlotSquared().getPlotAreaManager().getPlotArea(wrappedLoc);
+                Plot psPlot = area.getPlot(wrappedLoc);
                 if (area != null) {
                     Plot plot = area.getPlot(wrappedLoc);
                     UUID uuid = player.getUniqueId();
+                    if (psPlot == null) {
+                        player.sendMessage(ConfigManager.getMessage("messages.region_no_access"));
+                        return;
+                    }  
                     if (plot != null && (plot.isDenied(uuid) || (!plot.isOwner(uuid) && !plot.getMembers().contains(uuid) && !plot.getTrusted().contains(uuid)))) {
                         player.sendMessage(ConfigManager.getMessage("messages.region_no_access"));
                         return;

--- a/src/main/java/net/bestemor/villagermarket/listener/PlayerListener.java
+++ b/src/main/java/net/bestemor/villagermarket/listener/PlayerListener.java
@@ -217,11 +217,10 @@ public class PlayerListener implements Listener {
                         clickedLoc.getWorld().getName(), clickedLoc.getBlockX(), clickedLoc.getBlockY(), clickedLoc.getBlockZ());
 
                 PlotArea area = plotAPI.getPlotSquared().getPlotAreaManager().getPlotArea(wrappedLoc);
-                Plot psPlot = area.getPlot(wrappedLoc);
                 if (area != null) {
                     Plot plot = area.getPlot(wrappedLoc);
                     UUID uuid = player.getUniqueId();
-                    if (psPlot == null) {
+                    if (plot == null) {
                         player.sendMessage(ConfigManager.getMessage("messages.region_no_access"));
                         return;
                     }  


### PR DESCRIPTION
Fixed a bug where you could place shop spawn eggs on plotSquared street by checking if the clicked coordinates are inside a plot