### PR TITLE
make custom amount menu toggleable

### DIFF
--- a/src/main/java/net/bestemor/villagermarket/menu/EditItemMenu.java
+++ b/src/main/java/net/bestemor/villagermarket/menu/EditItemMenu.java
@@ -179,14 +179,14 @@ public class EditItemMenu extends Menu {
             item.cycleTradeMode();
             update();
         }));
-
-        content.setPlaced(PlacedClickable.fromConfig(p + "custom_amount_" + (item.isAllowCustomAmount() ? "enabled" : "disabled"), event -> {
-            Player player = (Player) event.getWhoClicked();
-            player.playSound(player.getLocation(), ConfigManager.getSound("sounds.menu_click"), 0.5f, 1);
-            item.setAllowCustomAmount(!item.isAllowCustomAmount());
-            update();
-        }));
-
+        if (ConfigManager.getBoolean("allow_custom_amount")) {
+            content.setPlaced(PlacedClickable.fromConfig(p + "custom_amount_" + (item.isAllowCustomAmount() ? "enabled" : "disabled"), event -> {
+                Player player = (Player) event.getWhoClicked();
+                player.playSound(player.getLocation(), ConfigManager.getSound("sounds.menu_click"), 0.5f, 1);
+                item.setAllowCustomAmount(!item.isAllowCustomAmount());
+                update();
+            }));
+        }
         content.setClickable(ConfigManager.getInt(p + "price.slot"), Clickable.of(priceItem, event -> {
             Player player = (Player) event.getWhoClicked();
             player.playSound(player.getLocation(), ConfigManager.getSound("sounds.menu_click"), 0.5f, 1);

--- a/src/main/java/net/bestemor/villagermarket/shop/ShopItem.java
+++ b/src/main/java/net/bestemor/villagermarket/shop/ShopItem.java
@@ -218,6 +218,9 @@ public class ShopItem {
     }
 
     public boolean isAllowCustomAmount() {
+        if (!ConfigManager.getBoolean("allow_custom_amount")) {
+            return false;
+        }
         return allowCustomAmount && !isItemTrade() && mode != COMMAND;
     }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -45,6 +45,8 @@ max_sell_amount: 64
 distribute_income: true
 #The admin shop that should open when doing /shop. Leave blank to disable.
 default_admin_shop: ""
+#Enable custom amount menu
+allow_custom_amount: true
 
 #----------------------- Villager settings -----------------------#
 


### PR DESCRIPTION
Adds a new config option allow_custom_amount.

- true (default) → custom amount menu enabled
- false → custom amount menu disabled