### PR TITLE
Fix infinite item glitch bug

### DIFF
--- a/src/main/java/net/bestemor/villagermarket/shop/ShopItem.java
+++ b/src/main/java/net/bestemor/villagermarket/shop/ShopItem.java
@@ -353,11 +353,13 @@ public class ShopItem {
             customer.sendMessage(ConfigManager.getMessage("messages.not_enough_stock"));
             return false;
         }
-        if (!isItemTrade() && verifyMode == SELL && itemTrade == null && economy.getBalance(customer) < getSellPrice().doubleValue()) {
+        if (!isItemTrade() && verifyMode == SELL && itemTrade == null
+                && economy.getBalance(customer) < getSellPrice(amount, true).doubleValue()) {
             customer.sendMessage(ConfigManager.getMessage("messages.not_enough_money"));
             return false;
         }
-        if (!isItemTrade() && verifyMode == BUY && owner != null && itemTrade == null && economy.getBalance(owner) < getBuyPrice().doubleValue()) {
+        if (!isItemTrade() && verifyMode == BUY && owner != null && itemTrade == null
+                && economy.getBalance(owner) < getBuyPrice(amount, true).doubleValue()) {
             customer.sendMessage(ConfigManager.getMessage("messages.owner_not_enough_money"));
             return false;
         }
@@ -402,13 +404,18 @@ public class ShopItem {
             builder.replace("%price%", ConfigManager.getString("quantity.free"));
             builder.replace("%price_per_unit%", ConfigManager.getString("quantity.free"));
         } else if (mode != BUY_AND_SELL) {
+            BigDecimal finalPrice = mode == SELL ? getBuyPrice(amount, true) : getSellPrice(amount, true);
             if (discount > 0) {
                 ChatColor c = VMUtils.getCodeBeforePlaceholder(ConfigManager.getStringList(lorePath), "%price%");
-                String prePrice = ConfigManager.getCurrencyBuilder("%price%").replaceCurrency("%price%", getSellPrice(amount, true)).build();
-                String currentPrice = ConfigManager.getCurrencyBuilder("%price%").replaceCurrency("%price%", getSellPrice(amount, true)).build();
+                String prePrice = ConfigManager.getCurrencyBuilder("%price%")
+                        .replaceCurrency("%price%", mode == SELL ? getSellPrice(amount, false) : getBuyPrice(amount, false))
+                        .build();
+                String currentPrice = ConfigManager.getCurrencyBuilder("%price%")
+                        .replaceCurrency("%price%", finalPrice)
+                        .build();
                 builder.replace("%price%", "§m" + prePrice + c + " " + currentPrice);
             } else {
-                builder.replaceCurrency("%price%", getSellPrice(amount, false));
+                builder.replaceCurrency("%price%", finalPrice);
             }
             builder.replaceCurrency("%price_per_unit%", getSellPrice().divide(BigDecimal.valueOf(getAmount()), RoundingMode.HALF_UP));
         } else {


### PR DESCRIPTION
## Abstract

This PR will fix the bug of item glitch bug.

## Background

Current implementation of `verifyPurchase` does not use `amount` value used by `BuyItemMenu` (introduced by https://github.com/Bestem0r/VillagerMarket/pull/32).
In addition, the return value of `withdrawPlayer` is not checked.
As result, when `BuyItemMenu amount * price > (player balance)` and `item amount * price < (player balance)`, `verifyPurchase` will return `true`.
Then, `withdrawPlayer` will fail, but item is given because the return value `withdrawPlayer` is not checked.

## Small bug fix
Price text in discount is not valid