### PR TITLE
feat(adminshop): add batch sell-all with limit-capped batches

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -47,6 +47,8 @@ distribute_income: true
 default_admin_shop: ""
 #Enable custom amount menu
 allow_custom_amount: true
+#Allow batch sell-all in admin shops (triggered by shift-click)
+admin_shop_batch_sell_all: true
 
 #----------------------- Villager settings -----------------------#
 

--- a/src/main/resources/de_DE.yml
+++ b/src/main/resources/de_DE.yml
@@ -81,6 +81,8 @@ messages:
   type_limit_admin: '&bBitte gebe im Chat das Kauf-/Verkaufslimit für diesen Artikel ein (&c0&bfür unbegrenzt)...'
   reached_sell_limit: '&cDu kannst nicht mehr von diesem Artikel verkaufen!'
   reached_buy_limit: '&cDu kannst nicht mehr von diesem Artikel kaufen!'
+  #Placeholders: %sold%, %total%, %unit%, %left%
+  batch_sell_partial: '&eSold %sold% of %total% (%unit% per trade). Left: %left%.'
   reached_command_limit: '&cDu hast das Kauflimit für diesen Befehl erreicht!'
   money_left: '&aDu hast noch %amount% übrig.'
   money_currently: '&aDu hast derzeit %amount%.'

--- a/src/main/resources/en_US.yml
+++ b/src/main/resources/en_US.yml
@@ -80,6 +80,8 @@ messages:
   type_limit_admin: "&bPlease type the buy/sell limit for this item in the chat (&c0 &bfor unlimited)..."
   reached_sell_limit: "&cYou can not sell more of this item!"
   reached_buy_limit: "&cYou can not buy more of this item!"
+  #Placeholders: %sold%, %total%, %unit%, %left%
+  batch_sell_partial: "&eSold %sold% of %total% (%unit% per trade). Left: %left%."
   reached_command_limit: "&cYou have reached the buy limit for this command!"
   money_left: "&aYou have %amount% left."
   money_currently: "&aYou currently have %amount%."

--- a/src/main/resources/es_ES.yml
+++ b/src/main/resources/es_ES.yml
@@ -80,6 +80,8 @@ messages:
   type_limit_admin: "&bEscribe el límite de compra/venta de este item el chat (&c0&bpara ilimitado)..."
   reached_sell_limit: "&cNo puedes vender más de este tipo de item!"
   reached_buy_limit: "&cNo puedes comprar más de este tipo de item!"
+  #Placeholders: %sold%, %total%, %unit%, %left%
+  batch_sell_partial: "&eSold %sold% of %total% (%unit% per trade). Left: %left%."
   reached_command_limit: "&cHas alcanzado el límite de compra para este comando!"
   money_left: "&aTe quedan %amount%."
   money_currently: "&aTu actualmente tienes %amount%."

--- a/src/main/resources/fr_FR.yml
+++ b/src/main/resources/fr_FR.yml
@@ -80,6 +80,8 @@ messages:
 
   reached_sell_limit: "&cVous ne pouvez pas vendre plus de cet article !"
   reached_buy_limit: "&cVous ne pouvez pas acheter plus de cet article !"
+  #Placeholders: %sold%, %total%, %unit%, %left%
+  batch_sell_partial: "&eSold %sold% of %total% (%unit% per trade). Left: %left%."
   reached_command_limit: "&cVous avez atteint la limite d'achat pour cette commande !"
   money_left: "&aIl vous reste %amount%."
   money_currently: "&aVous avez actuellement %amount%."

--- a/src/main/resources/pt_BR.yml
+++ b/src/main/resources/pt_BR.yml
@@ -80,6 +80,8 @@ messages:
   type_limit_admin: "&bPor favor digite um limite para compra/venda desse item no chat (&c0 &bpara ilimitado)..."
   reached_sell_limit: "&cVocê não pode vender mais desse item!"
   reached_buy_limit: "&cVocê não pode comprar mais desse item!"
+  #Placeholders: %sold%, %total%, %unit%, %left%
+  batch_sell_partial: "&eSold %sold% of %total% (%unit% per trade). Left: %left%."
   reached_command_limit: "&cVocê chegou a limite de compra por esse comando!"
   money_left: "&aVocê tem %amount% sobrando."
   money_currently: "&aAtualmente você tem %amount%."

--- a/src/main/resources/zh_CN.yml
+++ b/src/main/resources/zh_CN.yml
@@ -80,6 +80,8 @@ messages:
   type_limit_admin: "&b请在聊天栏中输入你想要你限制玩家交易的最大数量 (&c0 &b表示数量不限)..."
   reached_sell_limit: "&c你不能再出售更多该物品了!"
   reached_buy_limit: "&c你不能再购买更多该物品了!"
+  #Placeholders: %sold%, %total%, %unit%, %left%
+  batch_sell_partial: "&eSold %sold% of %total% (%unit% per trade). Left: %left%."
   reached_command_limit: "&c你已经达到该命令的购买次数限制了!"
   money_left: "&a当前余额为 %amount%."
   money_currently: "&a你当前余额为 %amount%."


### PR DESCRIPTION
## Motivation
This reduces repetitive clicks when players sell large stacks to admin buy shops, making the flow faster for players and less spammy for the server.

## Implementation
Adds a shift-click batch sell-all flow for admin shops in BUY mode, selling only full batches and respecting trade limits. The feature is controlled by `admin_shop_batch_sell_all` and surfaces a partial-sell notice via `messages.batch_sell_partial`. Limit and batch calculations are centralized in `ShopItem` so the same rules are reused across the flow.